### PR TITLE
opam: allow install on macOS

### DIFF
--- a/opam
+++ b/opam
@@ -25,4 +25,4 @@ depends: [
   "oasis" {build}
   "ounit" {test}
 ]
-available: [ocaml-version >= "4.01.0" & os = "linux"]
+available: [ocaml-version >= "4.01.0" & (os = "linux" | os = "darwin")]


### PR DESCRIPTION
macOS seems to have the necessary primitives, so the package can be marked as available on both "linux" and "darwin".

Signed-off-by: David Scott <dave@recoil.org>